### PR TITLE
Simplify transaction scenarios

### DIFF
--- a/features/transaction.feature
+++ b/features/transaction.feature
@@ -37,15 +37,13 @@ Feature: Transactions
     Scenario: A refund for an expense to an asset
         Given I have an asset account called "Cash"
         And I have an expense account called "Groceries"
-        And I have executed a transaction between "Cash" and "Groceries" for 1200 RSD
-        When I refund 200 RSD for the "Groceries" to "Cash"
-        Then I should have 1000 RSD funds less in "Cash" asset account
-        And I should have 1000 RSD funds more in "Groceries" expense account
+        When I refund 200 RSD from the "Cash" to "Groceries"
+        Then I should have 200 RSD funds more in "Cash" asset account
+        And I should have 200 RSD funds less in "Groceries" expense account
 
     Scenario: A payback to an asset for an expense
         Given I have an asset account called "Cash"
         And I have an expense account called "Groceries"
-        And I have executed a transaction between "Cash" and "Groceries" for 1200 RSD
         When I pay back 200 RSD from the "Groceries" to "Cash"
-        Then I should have 1000 RSD funds less in "Cash" asset account
-        And I should have 1000 RSD funds more in "Groceries" expense account
+        Then I should have 200 RSD funds more in "Cash" asset account
+        And I should have 200 RSD funds less in "Groceries" expense account

--- a/tests/PerFiFeatureTest/Domain/TransactionContext.php
+++ b/tests/PerFiFeatureTest/Domain/TransactionContext.php
@@ -81,26 +81,6 @@ class TransactionContext implements Context
     }
 
     /**
-     * @Given I have executed a transaction between :source and :destination for :amount :currency
-     */
-    public function iHaveExecutedATransactionBetweenTwoAccountsForAmountInCurrency($source, $destination, $amount, $currency)
-    {
-        $sourceAccount = $this->getAccountByTitle($source);
-        $destinationAccount = $this->getAccountByTitle($destination);
-        $description = "supermarket";
-
-        $this->command = new Pay(
-            $sourceAccount,
-            $destinationAccount,
-            $amount,
-            $currency,
-            $description
-        );
-
-        $this->commandHandler->__invoke($this->command);
-    }
-
-    /**
      * @When :amount :currency is payed for :description from :source to :destination
      */
     public function anAmountInCurrencyIsPayedForSomething($amount, $currency, $description, $source, $destination)
@@ -139,7 +119,7 @@ class TransactionContext implements Context
     }
 
     /**
-     * @When I refund :amount :currency for the :source to :destination
+     * @When I refund :amount :currency from the :source to :destination
      */
     public function iRefundAmountInCurrency($amount, $currency, $source, $destination)
     {
@@ -147,7 +127,7 @@ class TransactionContext implements Context
         $destinationAccount = $this->getAccountByTitle($destination);
         $description = "supermarket";
 
-        $command = new Refund(
+        $this->command = new Refund(
             $sourceAccount,
             $destinationAccount,
             $amount,
@@ -155,7 +135,7 @@ class TransactionContext implements Context
             $description
         );
 
-        $this->commandHandler->__invoke($command);
+        $this->commandHandler->__invoke($this->command);
     }
 
     /**
@@ -167,7 +147,7 @@ class TransactionContext implements Context
         $destinationAccount = $this->getAccountByTitle($destination);
         $description = "supermarket";
 
-        $command = new PayBack(
+        $this->command = new PayBack(
             $sourceAccount,
             $destinationAccount,
             $amount,
@@ -175,7 +155,7 @@ class TransactionContext implements Context
             $description
         );
 
-        $this->commandHandler->__invoke($command);
+        $this->commandHandler->__invoke($this->command);
     }
 
     /**


### PR DESCRIPTION
The refund and payback scenarios don't need
to have an existing pay transaciton to be able to test
them, so by removing that, makes the scenarios a bit
nicer and easier to follow.