### PR TITLE
Have empty data be an empty string not null

### DIFF
--- a/src/PerFi/PerFiBundle/Form/CreateAccountType.php
+++ b/src/PerFi/PerFiBundle/Form/CreateAccountType.php
@@ -24,6 +24,7 @@ class CreateAccountType extends AbstractType
             ])
             ->add('title', TextType::class, [
                 'required' => true,
+                'empty_data' => '',
             ]);
     }
 }

--- a/src/PerFi/PerFiBundle/Form/PayType.php
+++ b/src/PerFi/PerFiBundle/Form/PayType.php
@@ -36,6 +36,7 @@ class PayType extends AbstractType
             ])
             ->add('amount', TextType::class, [
                 'required' => true,
+                'empty_data' => '',
             ])
             ->add('currency', ChoiceType::class, [
                 'required' => true,
@@ -43,6 +44,7 @@ class PayType extends AbstractType
             ])
             ->add('description', TextType::class, [
                 'required' => true,
+                'empty_data' => '',
             ]);
     }
 


### PR DESCRIPTION
Apparently Symfony form converts empty data to
null by default. Setting it to an empty string,
converts empty data to an empty string and not
to null.