### PR TITLE
Get accounts for a transcation from the account repository

### DIFF
--- a/src/PerFi/Application/Factory/TransactionFactory.php
+++ b/src/PerFi/Application/Factory/TransactionFactory.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace PerFi\Application\Factory;
 
+use PerFi\Domain\Account\Account;
 use PerFi\Domain\MoneyFactory;
 use PerFi\Domain\Transaction\Transaction;
 use PerFi\Domain\Transaction\TransactionDate;
 use PerFi\Domain\Transaction\TransactionId;
 use PerFi\Domain\Transaction\TransactionRecordDate;
 use PerFi\Domain\Transaction\TransactionType;
-use PerFi\Application\Factory\AccountFactory;
 
 class TransactionFactory
 {
@@ -19,11 +19,8 @@ class TransactionFactory
      * @param array $transaction
      * @return Transaction
      */
-    public static function fromArray(array $transaction) : Transaction
+    public static function fromArray(array $transaction, Account $sourceAccount, Account $destinationAccount) : Transaction
     {
-        $sourceAccount = AccountFactory::fromArray(self::getSubArray($transaction, 'source_account'));
-        $destinationAccount = AccountFactory::fromArray(self::getSubArray($transaction, 'destination_account'));
-
         return Transaction::withId(
             TransactionId::fromString($transaction['transaction_id']),
             TransactionType::fromString($transaction['type']),
@@ -35,20 +32,5 @@ class TransactionFactory
             $transaction['description'],
             (bool) $transaction['refunded']
         );
-    }
-
-    private static function getSubArray(array $array, string $prefix) : array
-    {
-        $subArray = [];
-
-        foreach ($array as $key => $value) {
-            if (strpos($key, $prefix) === false) {
-                continue;
-            }
-
-            $subArray[substr($key, strlen($prefix) + 1)] = $value;
-        }
-
-        return $subArray;
     }
 }

--- a/src/PerFi/PerFiBundle/Resources/config/services.xml
+++ b/src/PerFi/PerFiBundle/Resources/config/services.xml
@@ -19,6 +19,7 @@ xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/sc
 
         <service id="perfi.repository.transaction" class="PerFi\Application\Repository\TransactionRepository">
             <argument type="service" id="database_connection"/>
+            <argument type="service" id="perfi.repository.account"/>
         </service>
         <!-- repositories -->
 

--- a/tests/PerFiUnitTest/Traits/AccountTrait.php
+++ b/tests/PerFiUnitTest/Traits/AccountTrait.php
@@ -6,6 +6,7 @@ namespace PerFiUnitTest\Traits;
 use Mockery as m;
 use PerFiUnitTest\Traits\AccountTypeTrait;
 use PerFi\Domain\Account\Account;
+use PerFi\Domain\Account\AccountId;
 use PerFi\Domain\Account\AccountRepository;
 
 trait AccountTrait
@@ -27,6 +28,9 @@ trait AccountTrait
         $account = m::mock(Account::class);
 
         if ($type == 'asset') {
+            $account->shouldReceive('id')
+                ->andReturn(AccountId::fromString('fddf4716-6c0e-4f54-b539-d2d480a50d1a'))
+                ->byDefault();
             $account->shouldReceive('type')
                 ->andReturn($this->asset())
                 ->byDefault();
@@ -34,6 +38,9 @@ trait AccountTrait
                 ->andReturn('Cash, asset')
                 ->byDefault();
         } else if ($type == 'expense') {
+            $account->shouldReceive('id')
+                ->andReturn(AccountId::fromString('fddf4716-6c0e-4f54-b539-d2d480a50d1b'))
+                ->byDefault();
             $account->shouldReceive('type')
                 ->andReturn($this->expense())
                 ->byDefault();
@@ -49,7 +56,6 @@ trait AccountTrait
     {
         $accountRepository = m::mock(AccountRepository::class);
         $accountRepository->shouldReceive('get')
-            ->times(count($accounts))
             ->andReturn(...$accounts);
 
         return $accountRepository;


### PR DESCRIPTION
Instead of joining the accounts table twice to get the
source and destination accounts of a transaction, get the
accounts from the account repository.